### PR TITLE
Updating to fix 'partial body not found' error

### DIFF
--- a/lib/assemble-handlebars.js
+++ b/lib/assemble-handlebars.js
@@ -1,4 +1,3 @@
-var grunt = require('grunt');
 var handlebars = require('handlebars');
 var helpers = require('helper-lib');
 
@@ -16,8 +15,6 @@ var plugin = function() {
   };
 
   var render = function(tmpl, options, callback) {
-    grunt.verbose.writeln('rendering handlebars');
-    grunt.verbose.writeln(require('util').inspect(engine));
     var content;
     try {
       if(typeof tmpl === 'string') {
@@ -37,7 +34,11 @@ var plugin = function() {
   var registerPartial = function(filename, content) {
     var tmpl;
     try {
-      tmpl = handlebars.compile(content);
+      if(typeof content === 'string') {
+        tmpl = handlebars.compile(content);
+      } else {
+        tmpl = content;
+      }
       handlebars.registerPartial(filename, tmpl);
     } catch (ex) {}
   };


### PR DESCRIPTION
Adding a check to see if the partial is already compiled or not before trying to compile and register it with Handlebars.
