### PR TITLE
Updating to use an older version of helper-lib

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "gruntplugin"
   ],
   "dependencies": {
-    "helper-lib": "latest",
+    "helper-lib": "~0.1.32",
     "handlebars": "latest",
     "lodash": "latest"
   }


### PR DESCRIPTION
Getting a cycle error that might be caused by trying to put the same version of helper-lib into itself
