### PR TITLE
Fixing package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,8 +47,8 @@
     "grunt": "~0.4.1"
   },
   "keywords": [
-    "assemble"
-    "handlebars"
+    "assemble",
+    "handlebars",
     "template"
   ],
   "dependencies": {


### PR DESCRIPTION
Syntax errors in package.json caused the build to fail during npm install
