### PR TITLE
remove partial pre-compiling (buggy)

### DIFF
--- a/lib/assemble-handlebars.js
+++ b/lib/assemble-handlebars.js
@@ -42,7 +42,6 @@ var plugin = function() {
   };
 
   var registerPartial = function(filename, content) {
-    var tmpl;
     try {
       handlebars.registerPartial(filename, content);
     } catch (ex) {}


### PR DESCRIPTION
Unless you have a working use case for passing a string template... it isn't working for me.
