### PR TITLE
bump version to 0.2.0.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,12 @@
+/*!
+ * assemble-handlebars
+ * https://github.com/assemble/assemble-handlebars
+ *
+ * Copyright (c) 2013 Assemble
+ * Licensed under the MIT license.
+ */
+
+
 var _ = require('lodash');
 var handlebars = require('handlebars');
 var helpers = null;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "assemble-handlebars",
   "description": "Handlebars engine plugin for Assemble, the static site generator for Grunt.js and Yeoman.",
-  "version": "0.1.11",
+  "version": "0.2.0",
   "homepage": "https://github.com/assemble/assemble-handlebars",
   "author": {
     "name": "Brian Woodward",


### PR DESCRIPTION
addresses assemble/handlebars-helpers/#98

Prior version, 0.1.11 was re-published with handlebars-helpers dependency version reverted to pre- 0.4.0
