### PR TITLE
Add root context lookup

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,12 @@ var _ = require('lodash');
 var handlebars = require('handlebars');
 var helpers = null;
 
+// Custom nameLookup
+var nameLookup = handlebars.JavaScriptCompiler.prototype.nameLookup;
+handlebars.JavaScriptCompiler.prototype.nameLookup = function (parent, name, type) {
+  return name.indexOf("root") === 0 ? 'data' : nameLookup(parent, name, type);
+};
+
 try {
   helpers = require('handlebars-helpers');
 } catch (ex) {
@@ -42,9 +48,9 @@ var plugin = function() {
     var content;
     try {
       if(typeof tmpl === 'string') {
-        tmpl = handlebars.compile(tmpl, options);
+        tmpl = handlebars.compile(tmpl, _.defaults({data: true}, options));
       }
-      content = tmpl(options);
+      content = tmpl(options, {data: options});
     } catch (ex) {
       callback(ex, null);
     }


### PR DESCRIPTION
Access to root context in partial by `{{root}}`.

ex.

```

---
name: foo
bar:
  name: bar

---
{{name}}
{{> leaf bar}}


leaf.hbs:
{{name}} {{root.name}}
```

of

```
foo
bar foo
```

See https://github.com/wycats/handlebars.js/pull/525#issuecomment-25759857
